### PR TITLE
Add v_pred training option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ A few example *.json config files have been prepared in ./config folder.
 ```bash
 accelerate launch train_lora_slider.py --pretrained_model_name_or_path runwayml/stable-diffusion-v1-5 --prompt_config_path config/age_slider.json
 ```
+If you have a local sd-scripts LoRA checkpoint you can use `--pretrained_peft_model_path`
+instead of `--pretrained_model_name_or_path`. Pass `--prediction_type v_prediction`
+to enable v-parameterization with v-pred noise loss.
 Note that you need to run `accelerate config` in CLI at the first time.
 The script saves a diffusers LoRA file in the output directory. Pass
 `--save_webui_checkpoint` if you also want a WebUI compatible

--- a/train_lora_slider_xl.py
+++ b/train_lora_slider_xl.py
@@ -146,7 +146,6 @@ def parse_args(input_args=None):
         "--pretrained_model_name_or_path",
         type=str,
         default=None,
-        required=True,
         help="Path to pretrained model or model identifier from huggingface.co/models.",
     )
     parser.add_argument(
@@ -411,6 +410,12 @@ def parse_args(input_args=None):
     # Sanity checks
     if args.prompt_config_path is None:
         raise ValueError("Need prompt_config_path.")
+    if args.pretrained_model_name_or_path is None and args.pretrained_peft_model_path is None:
+        raise ValueError(
+            "Specify either --pretrained_model_name_or_path or --pretrained_peft_model_path."
+        )
+    if args.pretrained_model_name_or_path is None:
+        args.pretrained_model_name_or_path = args.pretrained_peft_model_path
 
     return args
 
@@ -609,6 +614,8 @@ def main(args):
         tokenizer_one = pipeline.tokenizer
         tokenizer_two = pipeline.tokenizer_2
         noise_scheduler = pipeline.scheduler
+        if args.prediction_type is not None:
+            noise_scheduler.register_to_config(prediction_type=args.prediction_type)
         text_encoder_one = pipeline.text_encoder
         text_encoder_two = pipeline.text_encoder_2
         vae = pipeline.vae
@@ -641,6 +648,8 @@ def main(args):
         noise_scheduler = DDPMScheduler.from_pretrained(
             args.pretrained_model_name_or_path, subfolder="scheduler"
         )
+        if args.prediction_type is not None:
+            noise_scheduler.register_to_config(prediction_type=args.prediction_type)
         text_encoder_one = text_encoder_cls_one.from_pretrained(
             args.pretrained_model_name_or_path,
             subfolder="text_encoder",


### PR DESCRIPTION
## Summary
- add docs on using a local peft checkpoint with v_prediction
- allow training without --pretrained_model_name_or_path when --pretrained_peft_model_path is provided
- register prediction_type with scheduler for v-parameterization

## Testing
- `python -m py_compile train_lora_slider.py train_lora_slider_xl.py convert_diffusers_sdxl_lora_to_webui.py`